### PR TITLE
Allow default users pre-fistOpenDate through goingnowhere.org addresses.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This project aims to be a complete volunteer management system for the [Nowhere]
 
 When running, the volunteer facing site is at http://localhost:3000/
 
-The admin password is admin@example.com / testtest
-A normal user account is created with normal@example.com / testtest
+The admin password is admin@goingnowhere.org / testtest
+A normal user account is created with normal@goingnowhere.org / testtest
 
 It was originally written in Coffeescript using Blaze as the view layer. In order to increase the pool of potential contributors and to escape the poor development experience of Blaze it is currently being ported to React and Javascript. This leads to some odd behaviour at the moment as it's currently using both technologies at the same time.
 

--- a/imports/fixtures/users-fixtures.js
+++ b/imports/fixtures/users-fixtures.js
@@ -5,19 +5,19 @@ import { Accounts } from 'meteor/accounts-base'
 const defaultUsers = [
   {
     name: 'manager',
-    email: 'manager@example.com',
+    email: 'manager@goingnowhere.org',
     password: 'testtest',
     roles: ['manager'],
   },
   {
     name: 'admin',
-    email: 'admin@example.com',
+    email: 'admin@goingnowhere.org',
     password: 'testtest',
     roles: ['admin'],
   },
   {
     name: 'normal user',
-    email: 'normal@example.com',
+    email: 'normal@goingnowhere.org',
     password: 'testtest',
     roles: [],
   },


### PR DESCRIPTION
To resolve the minor frustration that the default accounts promised in the README won't actually be created half of the year, due to the ban on non-goingnowhere.org signups pre-fistOpenDate.

(I assume the other development defaults to not suffice for sending out mails without further configuration, so using the actual goingnowhere domain should not too easily cause havoc.)