### PR TITLE
In intoleranceOptions, map "peppers" to actual "Peppers" rather than "Fish/Shellfish".

### DIFF
--- a/client/components/volunteer/VolunteerForm.jsx
+++ b/client/components/volunteer/VolunteerForm.jsx
@@ -42,7 +42,7 @@ const allergyOptions = [
 ]
 const intoleranceOptions = [
   ['gluten', 'Intolerance to gluten'],
-  ['peppers', 'Fish/shellfish'],
+  ['peppers', 'Peppers'],
   ['shellfish', 'Shellfish'],
   ['nuts', 'Peanuts/Nuts'],
   ['egg', 'Egg'],


### PR DESCRIPTION
I do believe this be the proper labeling based on past code history, i.e. https://github.com/goingnowhere/volunteers-nowhere/commit/199f99fa201dc486a5fb1810c4402e85530acb27 … If indeed this mapping was intentional for some reason, please ignore!

(I also noticed  that "shellfish" maps to "Shellfish" in the intoleranceOptions, but to "Fish/Shellfish" in the allergyOptions – but I wouldn't know what's the better mapping.)